### PR TITLE
Add Assembly metrics tracker

### DIFF
--- a/app/views/shared/_ga_tracker.html.erb
+++ b/app/views/shared/_ga_tracker.html.erb
@@ -9,3 +9,18 @@
     ga('send', 'pageview');
   </script>
 <% end %>
+
+<% if ENV['ASMLYTICS_APP_ID'] %>
+  <script type="text/javascript">
+    ;(function(p,l,o,w,i){if(!p[i]){p.__asml=p.__asml||[];
+    p.__asml.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
+    };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
+    n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://d1uxm17u44dmmr.cloudfront.net/1.0.0/asml.js","asml"));
+    asml('create', '<%= ENV['ASMLYTICS_APP_ID'] %>');
+    <% if signed_in? %>
+      asml('track', '<%= current_user.email %>');
+    <% else %>
+      asml('track');
+    <% end %>
+  </script>
+<% end %>


### PR DESCRIPTION
This collects metrics and adds a metrics screen on Assembly so everyone can see Signup sumo numbers.

ASMLYTICS_APP_ID will need to be set based on the code: https://assembly.com/signupsumo/metrics